### PR TITLE
Post state refactor cleanup

### DIFF
--- a/examples/data_reader.py
+++ b/examples/data_reader.py
@@ -2,7 +2,7 @@ from typing import List
 
 import numpy as np
 
-from ml_tools import State, StateSeries
+from ml_tools import State, StateSeries, SeriesCollection
 from ml_tools.utils.h5_utils import get_groups_with_prefix
 
 class DataReader():
@@ -11,7 +11,7 @@ class DataReader():
 
     def read_data(file_name:          str,
                   num_procs:          int = 1,
-                  random_sample_size: int = None) -> List[StateSeries]:
+                  random_sample_size: int = None) -> SeriesCollection:
         """ Method for reading all relevent data from the HDF5 file
 
         Parameters
@@ -26,10 +26,10 @@ class DataReader():
 
         Returns
         -------
-        List[StateSeries]
-            The relevent data for all states.  This is returned as a list of state series
+        SeriesCollection
+            The relevent data for all states.  This is returned as a SeriesCollection
             because that is what the prediction strategies take.  These are effectively a
-            list of series with length 1 (i.e., list of single state points)
+            list of StateSeries with length 1 (i.e., list of single state points)
         """
 
         features_to_read = [    "2d_assembly_exposure", "average_enrichment",
@@ -47,7 +47,7 @@ class DataReader():
             state.features["average_exposure"]       = np.nan_to_num(state["2d_assembly_exposure"], nan=0.)
             state.features["assembly_enrichment"]    = np.nan_to_num(state["average_enrichment"], nan=0.)
 
-        # Convert state data to list of state series
-        series = [[state] for state in states]
+        # Convert state data to SeriesCollection
+        collection = SeriesCollection([StateSeries([state]) for state in states])
 
-        return series
+        return collection

--- a/examples/dnn_optimizer.py
+++ b/examples/dnn_optimizer.py
@@ -9,6 +9,7 @@ from skopt import gp_minimize
 from skopt.space import Real, Integer, Categorical
 from skopt.utils import use_named_args
 
+from ml_tools import SeriesCollection
 from ml_tools.model.prediction_strategy import PredictionStrategy, FeatureProcessor
 from ml_tools.model.nn_strategy import Activation, NNStrategy, Dense, LayerSequence
 from optimizer import Optimizer
@@ -55,8 +56,8 @@ class DNNSkoptOptimizer(DNNOptimizer):
         A dictionary specifying the input features of this model and their corresponding feature processing strategy
     predicted_feature : str
         The string specifying the feature to be predicted
-    state_series : List[StateSeries]
-        The input state series which to predict outputs for
+    series_collection : SeriesCollection
+        The input state series collection which to predict outputs for
     num_procs : int
         The number of parallel processors to use when reading data from the HDF5
     test_fraction : float
@@ -78,7 +79,7 @@ class DNNSkoptOptimizer(DNNOptimizer):
                  dimensions:           Dimensions,
                  input_features:       Dict[str, FeatureProcessor],
                  predicted_feature:    str,
-                 state_series:         List[StateSeries],
+                 series_collection:    SeriesCollection,
                  num_procs:            int = 1,
                  test_fraction:        int = 0.2,
                  number_of_folds:      int = 5,
@@ -89,7 +90,7 @@ class DNNSkoptOptimizer(DNNOptimizer):
         self.dimensions           = dimensions
         self.input_features       = input_features
         self.predicted_feature    = predicted_feature
-        self.state_series         = state_series
+        self.series_collection    = series_collection
         self.num_procs            = num_procs
         self.test_fraction        = test_fraction
         self.number_of_folds      = number_of_folds
@@ -149,11 +150,11 @@ class DNNSkoptOptimizer(DNNOptimizer):
 
             rms = []
             kf = KFold(n_splits=self.number_of_folds, shuffle=True)
-            for fold, (train_idx, val_idx) in enumerate(kf.split(self.state_series)):
+            for fold, (train_idx, val_idx) in enumerate(kf.split(self.series_collection)):
                 print(f"Starting fold {fold + 1}/{self.number_of_folds}...")
 
-                training_set   = [self.state_series[i] for i in train_idx]
-                validation_set = [self.state_series[i] for i in val_idx]
+                training_set   = [self.series_collection[i] for i in train_idx]
+                validation_set = [self.series_collection[i] for i in val_idx]
 
                 model = self._build_model(initial_learning_rate = params["initial_learning_rate"],
                                           learning_decay_rate   = params["learning_decay_rate"],
@@ -214,8 +215,8 @@ class DNNOptunaOptimizer(DNNOptimizer):
         A dictionary specifying the input features of this model and their corresponding feature processing strategy
     predicted_feature : str
         The string specifying the feature to be predicted
-    state_series : List[StateSeries]
-        The input state series which to predict outputs for
+    series_collection : SeriesCollection
+        The input state series collection which to predict outputs for
     num_procs : int
         The number of parallel processors to use when reading data from the HDF5
     test_fraction : float
@@ -237,7 +238,7 @@ class DNNOptunaOptimizer(DNNOptimizer):
                  dimensions:           Dimensions,
                  input_features:       Dict[str, FeatureProcessor],
                  predicted_feature:    str,
-                 state_series:         List[StateSeries],
+                 series_collection:    SeriesCollection,
                  num_procs:            int = 1,
                  test_fraction:        int = 0.2,
                  number_of_folds:      int = 5,
@@ -248,7 +249,7 @@ class DNNOptunaOptimizer(DNNOptimizer):
         self.dimensions           = dimensions
         self.input_features       = input_features
         self.predicted_feature    = predicted_feature
-        self.state_series         = state_series
+        self.series_collection    = series_collection
         self.num_procs            = num_procs
         self.test_fraction        = test_fraction
         self.number_of_folds      = number_of_folds
@@ -308,11 +309,11 @@ class DNNOptunaOptimizer(DNNOptimizer):
 
             rms = []
             kf = KFold(n_splits=self.number_of_folds, shuffle=True)
-            for fold, (train_idx, val_idx) in enumerate(kf.split(self.state_series)):
+            for fold, (train_idx, val_idx) in enumerate(kf.split(self.series_collection)):
                 print(f"Starting fold {fold + 1}/{self.number_of_folds}...")
 
-                training_set   = [self.state_series[i] for i in train_idx]
-                validation_set = [self.state_series[i] for i in val_idx]
+                training_set   = [self.series_collection[i] for i in train_idx]
+                validation_set = [self.series_collection[i] for i in val_idx]
 
                 model = self._build_model(initial_learning_rate = initial_learning_rate,
                                           learning_decay_rate   = learning_decay_rate,

--- a/examples/evaluate.py
+++ b/examples/evaluate.py
@@ -13,7 +13,7 @@ tf.get_logger().setLevel("ERROR")
 
 from sklearn.model_selection import train_test_split
 
-from ml_tools import MinMaxNormalize, NoProcessing, StateSeries, PredictionStrategy, GBMStrategy, NNStrategy, \
+from ml_tools import MinMaxNormalize, NoProcessing, SeriesCollection, PredictionStrategy, GBMStrategy, NNStrategy, \
                      NormalPerturbator, RelativeNormalPerturbator
 from ml_tools.utils.plotting import plot_ref_vs_pred, plot_hist, plot_sensitivities, print_metrics, plot_corr_matrix, \
                                     plot_ice_pdp, plot_shap
@@ -45,7 +45,7 @@ def main() -> None:
     """ Example code for doing a model optimization followed by comparison to other models
     """
 
-    state_series = DataReader.read_data(file_name = "sample.h5", num_procs = 20)
+    series_collection = DataReader.read_data(file_name = "sample.h5", num_procs = 20)
 
     models = {}
     models['GBM'] = GBMStrategy(input_features, predicted_feature)
@@ -63,7 +63,7 @@ def main() -> None:
     optimizer = DNNOptunaOptimizer(dimensions           = search_space,
                                    input_features       = input_features,
                                    predicted_feature    = predicted_feature,
-                                   state_series         = random.sample(state_series, 10000),
+                                   series_collection    = random.sample(series_collection, 10000),
                                    num_procs            = 20,
                                    test_fraction        = 0.2,
                                    number_of_folds      = 5,
@@ -103,7 +103,7 @@ def main() -> None:
     optimizer = CNNOptunaOptimizer(dimensions           = search_space,
                                    input_features       = input_features,
                                    predicted_feature    = predicted_feature,
-                                   state_series         = random.sample(state_series, 10000),
+                                   series_collection    = random.sample(series_collection, 10000),
                                    num_procs            = 20,
                                    test_fraction        = 0.2,
                                    number_of_folds      = 5,
@@ -121,8 +121,8 @@ def main() -> None:
     with open("cnn.pkl", 'rb') as file:
         models['CNN'] = pickle.load(file)
 
-    train_series, valid_series = train_test_split(state_series, test_size=0.2)
-    train(models, train_series)
+    train_collection, valid_collection = train_test_split(series_collection, test_size=0.2)
+    train(models, train_collection)
 
     models['GBM - GBM_Informed']               = deepcopy(models['GBM'])
     models['DNN - GBM_Informed']               = deepcopy(models['DNN'])
@@ -131,21 +131,21 @@ def main() -> None:
     models['DNN - GBM_Informed'].biasing_model = models['GBM']
     models['CNN - GBM_Informed'].biasing_model = models['GBM']
 
-    train({name: model for name, model in models.items() if 'GBM_Informed' in name}, train_series)
+    train({name: model for name, model in models.items() if 'GBM_Informed' in name}, train_collection)
 
-    evaluate(models, valid_series)
+    evaluate(models, valid_collection)
 
 
 
-def train(models: Dict[str, PredictionStrategy], train_series: List[StateSeries]) -> None:
+def train(models: Dict[str, PredictionStrategy], train_collection: SeriesCollection) -> None:
     """ Basic function for training all models
 
     Parameters
     ----------
     models : Dict[str, PredictionStrategy]
         Models to be trained
-    train_series : List[StateSeries]
-        State series data to use for training
+    train_collection : SeriesCollection
+        State series collection data to use for training
     """
 
     print('Training models...')
@@ -153,22 +153,22 @@ def train(models: Dict[str, PredictionStrategy], train_series: List[StateSeries]
         print(f'Training {name:s}...')
         start = time.time()
         if name in ['GBM', 'GBM - GBM_Informed']:
-            train_data, test_data = train_test_split(train_series, test_size=0.2)
+            train_data, test_data = train_test_split(train_collection, test_size=0.2)
             model.train(train_data, test_data)
         else:
-            model.train(train_series)
+            model.train(train_collection)
         print(f'  in {time.time()-start:.2f} seconds')
 
 
-def evaluate(models: Dict[str, PredictionStrategy], valid_series: List[StateSeries]) -> None:
+def evaluate(models: Dict[str, PredictionStrategy], valid_collection: SeriesCollection) -> None:
     """Basic function for plotting evaluation results
 
     Parameters
     ----------
     models : Dict[str, PredictionStrategy]
         Models to be evaluated
-    valid_series : List[StateSeries]
-        State series data to use for validation
+    valid_collection : SeriesCollection
+        State series collection data to use for validation
     """
 
     print('Printing Results...')
@@ -177,46 +177,46 @@ def evaluate(models: Dict[str, PredictionStrategy], valid_series: List[StateSeri
     gbm_informed_models    = {name: model for name, model in models.items() if 'GBM_Informed' in name}
 
     print('Plotting Correlation Matrix...')
-    plot_corr_matrix(scalar_features, valid_series, fig_name = "corr_matrix")
+    plot_corr_matrix(scalar_features, valid_collection, fig_name = "corr_matrix")
 
     print('Plotting Reference vs. Predicted Plots...')
-    plot_ref_vs_pred(           base_models, valid_series, title=False, fig_name = "ref_vs_pred_base")
-    plot_ref_vs_pred(   gbm_informed_models, valid_series, title=False, fig_name = "ref_vs_pred_gbm_informed")
+    plot_ref_vs_pred(           base_models, valid_collection, title=False, fig_name = "ref_vs_pred_base")
+    plot_ref_vs_pred(   gbm_informed_models, valid_collection, title=False, fig_name = "ref_vs_pred_gbm_informed")
 
 
     print('Plotting Histograms Plots...')
-    plot_hist(           base_models, valid_series, fig_name = "hist_base")
-    plot_hist(   gbm_informed_models, valid_series, fig_name = "hist_gbm_informed")
+    plot_hist(           base_models, valid_collection, fig_name = "hist_base")
+    plot_hist(   gbm_informed_models, valid_collection, fig_name = "hist_gbm_informed")
 
     print('Plotting ICE/PDP Plots...')
-    plot_ice_pdp(gbm_informed_models, valid_series, "boron_concentration", num_points=1000, fig_name_prefix = "ice_pdp_boron"    , num_procs=20)
+    plot_ice_pdp(gbm_informed_models, valid_collection, "boron_concentration", num_points=1000, fig_name_prefix = "ice_pdp_boron"    , num_procs=20)
 
     print('Plotting SHAP Plots...')
     feature_plots = {"scalars"         : scalar_features,
                      "avg_exp"         : ["average_exposure"],
                      "assem_enr"       : ["assembly_enrichment"],
                      "incore_det"      : ["measured_fixed_detector"]}
-    plot_shap(gbm_informed_models, valid_series, feature_plots, num_samples=1000, num_procs=20)
+    plot_shap(gbm_informed_models, valid_collection, feature_plots, num_samples=1000, num_procs=20)
 
-    print_metrics(models, valid_series)
+    print_metrics(models, valid_collection)
 
     perturbators = {'measured_fixed_detector' : RelativeNormalPerturbator(0.026),
                     'assembly_enrichment'     : NormalPerturbator(0.00005),
                     'average_exposure'        : RelativeNormalPerturbator(0.02),
                     'boron_concentration'     : NormalPerturbator(5.0)}
 
-    pert_states = random.sample(valid_series, 100)
+    pert_collection = random.sample(valid_collection, 100)
 
     print('Plotting Sensitivities Plots...')
     plot_sensitivities(models                  = base_models,
-                       state_series            = pert_states,
+                       series_collection       = pert_collection,
                        perturbators            = perturbators,
                        number_of_perturbations = 100,
                        num_procs               = 30,
                        fig_name_prefix         = "box_plot_base")
 
     plot_sensitivities(models                  = informed_models,
-                       state_series            = pert_states,
+                       series_collection       = pert_collection,
                        perturbators            = perturbators,
                        number_of_perturbations = 100,
                        num_procs               = 30,

--- a/examples/optimizer.py
+++ b/examples/optimizer.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import List, Dict, Tuple, Optional
 
+from ml_tools import SeriesCollection
 from ml_tools.model.prediction_strategy import PredictionStrategy, FeatureProcessor
 from ml_tools.model.nn_strategy import Activation
 
@@ -18,7 +19,7 @@ class Optimizer(ABC):
         A dictionary specifying the input features of this model and their corresponding feature processing strategy
     predicted_feature : str
         The string specifying the feature to be predicted
-    state_series : List[StateSeries]
+    series_collection : SeriesCollection
         The input state series which to predict outputs for
     num_procs : int
         The number of parallel processors to use when reading data from the HDF5
@@ -111,13 +112,13 @@ class Optimizer(ABC):
         self._predicted_feature = predicted_feature
 
     @property
-    def state_series(self) -> List[StateSeries]:
-        return self._state_series
+    def series_collection(self) -> SeriesCollection:
+        return self._series_collection
 
-    @state_series.setter
-    def state_series(self, state_series: List[StateSeries]) -> None:
-        assert len(state_series) > 0, f"len(state_series) = {len(state_series)}"
-        self._state_series = state_series
+    @series_collection.setter
+    def series_collection(self, series_collection: SeriesCollection) -> None:
+        assert len(series_collection) > 0, f"len(series_collection) = {len(series_collection)}"
+        self._series_collection = series_collection
 
     @property
     def num_procs(self) -> int:


### PR DESCRIPTION
This PR propagates the state refactor to the examples as well as makes some minor tweaks to some of the plots to make them more legible.  Also, reverted `read_states_from_hdf5` back onto `State` because it is intended for reading multiple states from an HDF5 file, and not for creating a `StateSeries` from and HDF5 file.